### PR TITLE
StringChecker add methods [empty, notEmpty]

### DIFF
--- a/src/Checker/StringChecker.php
+++ b/src/Checker/StringChecker.php
@@ -10,11 +10,13 @@ use Spiral\Validator\AbstractChecker;
 final class StringChecker extends AbstractChecker implements SingletonInterface
 {
     public const MESSAGES = [
-        'regexp'  => '[[Value does not match required pattern.]]',
-        'shorter' => '[[Enter text shorter or equal to {1}.]]',
-        'longer'  => '[[Text must be longer or equal to {1}.]]',
-        'length'  => '[[Text length must be exactly equal to {1}.]]',
-        'range'   => '[[Text length should be in range of {1}-{2}.]]',
+        'regexp'   => '[[Value does not match required pattern.]]',
+        'shorter'  => '[[Enter text shorter or equal to {1}.]]',
+        'longer'   => '[[Text must be longer or equal to {1}.]]',
+        'length'   => '[[Text length must be exactly equal to {1}.]]',
+        'range'    => '[[Text length should be in range of {1}-{2}.]]',
+        'empty'    => '[[String value should be empty]]',
+        'notEmpty' => '[[String value should not be empty]]',
     ];
 
     /**
@@ -62,5 +64,21 @@ final class StringChecker extends AbstractChecker implements SingletonInterface
 
         return (\mb_strlen($trimmed) >= $min)
             && (\mb_strlen($trimmed) <= $max);
+    }
+
+    /**
+     * Check string is empty
+     */
+    public function empty(mixed $value): bool
+    {
+        return \is_string($value) && '' === trim($value);
+    }
+
+    /**
+     * Check string is not empty
+     */
+    public function notEmpty(mixed $value): bool
+    {
+        return \is_string($value) && '' !== trim($value);
     }
 }

--- a/tests/src/Unit/Checkers/StringsTest.php
+++ b/tests/src/Unit/Checkers/StringsTest.php
@@ -87,4 +87,48 @@ final class StringsTest extends TestCase
         $this->assertFalse($checker->regexp(null, '/^abc$/'));
         $this->assertFalse($checker->regexp([], '/^ab[dEC]{3}/i'));
     }
+
+    /**
+     * @dataProvider dataEmpty
+     */
+    public function testEmpty(mixed $value, bool $expectedResult): void
+    {
+        self::assertSame($expectedResult, (new StringChecker())->empty($value));
+    }
+
+    public function dataEmpty(): iterable
+    {
+        yield ['', true];
+        yield ["   \n     \t      ", true];
+        yield ['1', false];
+        yield ['0', false];
+        //not string
+        yield [null, false];
+        yield [1, false];
+        yield [1.0, false];
+        yield [[], false];
+        yield [new \stdClass(), false];
+    }
+
+    /**
+     * @dataProvider dataNotEmpty
+     */
+    public function testNotEmpty(mixed $value, bool $expectedResult): void
+    {
+        self::assertSame($expectedResult, (new StringChecker())->notEmpty($value));
+    }
+
+    public function dataNotEmpty(): iterable
+    {
+        yield ['', false];
+        yield ["   \n     \t      ", false];
+        yield ['1', true];
+        yield ['0', true];
+        //not string
+        yield [null, false];
+        yield [1, false];
+        yield [1.0, false];
+        yield [[], false];
+        yield [new \stdClass(), false];
+    }
 }


### PR DESCRIPTION
I need a method that checks only strings on emptiness. If it's not string I don't care which value it contains.
The checker `type::notEmpty` can't help me because it consider null as empty.

```php
$data = [
  'nullValue' => null,
  'emptyString' => '',
  'notEmptyString' => 'hi all',
];
$validator->validate($data, [
  'nullValue' => [
    ['string::empty'] // false
  ],
  'emptyString' => [
    ['string::empty'] // true
  ],
  'emptyString' => [
    ['string::notEmpty'] // false
  ],
  'notEmptyString' => [
    ['string::empty'] // false
  ],
  'notEmptyString' => [
    ['string::notEmpty'] // true
  ],
]);
```