### PR TITLE
ArrayChecker add methods [isList, isAssoc]

### DIFF
--- a/src/Checker/ArrayChecker.php
+++ b/src/Checker/ArrayChecker.php
@@ -15,6 +15,8 @@ class ArrayChecker extends AbstractChecker
         'longer' => '[[Number of elements must be equal to or greater than {1}.]]',
         'shorter' => '[[Number of elements must be equal to or less than {1}.]]',
         'range' => '[[Number of elements must be between {1} and {2}.]]',
+        'isList' => '[[Array is not list]]',
+        'isAssoc' => '[[Array is not associative]]',
     ];
 
     public function __construct(
@@ -73,5 +75,15 @@ class ArrayChecker extends AbstractChecker
         $count = \count($value);
 
         return $count >= $min && $count <= $max;
+    }
+
+    public function isList(mixed $value): bool
+    {
+        return is_array($value) && array_is_list($value);
+    }
+
+    public function isAssoc(mixed $value): bool
+    {
+        return is_array($value) && !array_is_list($value);
     }
 }

--- a/tests/src/Unit/Checkers/ArrayTest.php
+++ b/tests/src/Unit/Checkers/ArrayTest.php
@@ -89,4 +89,84 @@ final class ArrayTest extends BaseTest
             }
         };
     }
+
+    /**
+     * @dataProvider dataIsList
+     */
+    public function testIsList(mixed $value, bool $expectedResult): void
+    {
+        /** @var ArrayChecker $checker */
+        $checker = $this->container->get(ArrayChecker::class);
+        self::assertSame($expectedResult, $checker->isList($value));
+    }
+
+    public function dataIsList(): iterable
+    {
+        yield [[], true];
+        yield [[1, 2, 3], true];
+        yield [['a', 'b', 'c'], true];
+        yield [
+            [0 => 'a', 1 => 'b', 2 => 'c'],
+            true,
+        ];
+        yield [
+            ['0' => 'a', '1' => 'b', '2' => 'c'],
+            true,
+        ];
+        yield [
+            ['name' => 'name', 1, 2, 3],
+            false,
+        ];
+        yield [
+            ['name' => 'foo', 'surname' => 'bar'],
+            false,
+        ];
+
+        yield ['', false];
+        yield [1, false];
+        yield [2.0, false];
+        yield ['foo', false];
+        yield [null, false];
+        yield [new \stdClass(), false];
+    }
+
+    /**
+     * @dataProvider dataIsAssoc
+     */
+    public function testIsAssoc(mixed $value, bool $expectedResult): void
+    {
+        /** @var ArrayChecker $checker */
+        $checker = $this->container->get(ArrayChecker::class);
+        self::assertSame($expectedResult, $checker->isAssoc($value));
+    }
+
+    public function dataIsAssoc(): iterable
+    {
+        yield [[], false];
+        yield [[1, 2, 3], false];
+        yield [['a', 'b', 'c'], false];
+        yield [
+            [0 => 'a', 1 => 'b', 2 => 'c'],
+            false,
+        ];
+        yield [
+            ['0' => 'a', '1' => 'b', '2' => 'c'],
+            false,
+        ];
+        yield [
+            ['name' => 'name', 1, 2, 3],
+            true,
+        ];
+        yield [
+            ['name' => 'foo', 'surname' => 'bar'],
+            true,
+        ];
+
+        yield ['', false];
+        yield [1, false];
+        yield [2.0, false];
+        yield ['foo', false];
+        yield [null, false];
+        yield [new \stdClass(), false];
+    }
 }


### PR DESCRIPTION
```php
$data = [
  'listArray' => [1,2,3,4],
  'assocArray' => ['foo' => 1, 'bar' => 2]
];
$validator->validate($data, [
  'listArray' => [
    ['array::isList']
  ],
  'assocArray' => [
    ['array::isAssoc']
  ]
]);
```