### PR TITLE
MixedChecker add `accepted` and `declined`

### DIFF
--- a/src/Checker/MixedChecker.php
+++ b/src/Checker/MixedChecker.php
@@ -12,6 +12,8 @@ final class MixedChecker extends AbstractChecker implements SingletonInterface
     public const MESSAGES = [
         'cardNumber' => '[[Please enter valid card number.]]',
         'match'      => '[[Fields {1} and {2} do not match.]]',
+        'accepted'   => '[[Is not accepted.]]',
+        'declined'   => '[[Is not declined.]]',
     ];
 
     /**
@@ -55,5 +57,21 @@ final class MixedChecker extends AbstractChecker implements SingletonInterface
         }
 
         return $value == $this->getValidator()->getValue($field, null);
+    }
+
+    /**
+     * This is useful for validating "Terms of Service" acceptance or similar fields.
+     */
+    public function accepted(mixed $value): bool
+    {
+        return in_array($value, [true, 1, '1', 'yes', 'on'], true);
+    }
+
+    /**
+     * Opposite version of `accepted`.
+     */
+    public function declined(mixed $value): bool
+    {
+        return in_array($value, [false, 0, '0', 'no', 'off'], true);
     }
 }

--- a/tests/src/Unit/Checkers/MixedTest.php
+++ b/tests/src/Unit/Checkers/MixedTest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Spiral\Validator\Tests\Unit\Checkers;
 
 use PHPUnit\Framework\TestCase;
-use Spiral\Validator\Checker\MixedChecker;
 use Spiral\Validation\ValidatorInterface;
+use Spiral\Validator\Checker\MixedChecker;
 
 final class MixedTest extends TestCase
 {
     /**
      * @dataProvider cardsProvider
-     * @param bool  $expected
+     * @param bool $expected
      * @param mixed $card
      */
     public function testCardNumber(bool $expected, $card): void
@@ -62,5 +62,71 @@ final class MixedTest extends TestCase
             [false, 'abc'],
             [false, []],
         ];
+    }
+
+    /**
+     * @dataProvider dataAccepted
+     */
+    public function testAccepted(mixed $value, bool $expectedResult = true): void
+    {
+        $checker = new MixedChecker();
+        self::assertSame($expectedResult, $checker->accepted($value));
+    }
+
+    public function dataAccepted(): iterable
+    {
+        yield [true];
+        yield [1];
+        yield ['1'];
+        yield ['yes'];
+        yield ['on'];
+        // declined values
+        yield [false, false];
+        yield [0, false];
+        yield ['0', false];
+        yield ['no', false];
+        yield ['off', false];
+        // invalid values
+        yield [2, false];
+        yield ['2', false];
+        yield ['', false];
+        yield ["   \n     \t      ", false];
+        yield [null, false];
+        yield [1.0, false];
+        yield [[], false];
+        yield [new \stdClass(), false];
+    }
+
+    /**
+     * @dataProvider dataDeclined
+     */
+    public function testDeclined(mixed $value, bool $expectedResult = true): void
+    {
+        $checker = new MixedChecker();
+        self::assertSame($expectedResult, $checker->declined($value));
+    }
+
+    public function dataDeclined(): iterable
+    {
+        yield [false];
+        yield [0];
+        yield ['0'];
+        yield ['no'];
+        yield ['off'];
+        // accepted values
+        yield [true, false];
+        yield [1, false];
+        yield ['1', false];
+        yield ['yes', false];
+        yield ['on', false];
+        // invalid values
+        yield [2, false];
+        yield ['2', false];
+        yield ['', false];
+        yield ["   \n     \t      ", false];
+        yield [null, false];
+        yield [1.0, false];
+        yield [[], false];
+        yield [new \stdClass(), false];
     }
 }


### PR DESCRIPTION
 For handle forms and GET bool-like values.

```php
$data = [
 'i_accepte_term_of_service' => 'yes', // or [true, 1, '1', 'on']
 'user_want_to_do_bad_things' => 'no', // or [false, 0, '0', 'off']
];


$validator->validate($data, [
  'i_accepte_term_of_service' => [
    ['mixed::accepted']
  ],
  'user_want_to_do_bad_things' => [
    ['mixed::declined']
  ]
]);
```