### PR TITLE
TypeChecker::boolean add option for strict comparison

### DIFF
--- a/src/Checker/TypeChecker.php
+++ b/src/Checker/TypeChecker.php
@@ -33,8 +33,12 @@ final class TypeChecker extends AbstractChecker implements SingletonInterface
     /**
      * Value has to be boolean or integer[0,1].
      */
-    public function boolean(mixed $value): bool
+    public function boolean(mixed $value, bool $strict = false): bool
     {
-        return \is_bool($value) || (\is_numeric($value) && ($value === 0 || $value === 1));
+        if (\is_bool($value)) {
+            return true;
+        }
+
+        return  false === $strict && (\is_numeric($value) && ($value === 0 || $value === 1));
     }
 }

--- a/tests/src/Unit/Checkers/TypesTest.php
+++ b/tests/src/Unit/Checkers/TypesTest.php
@@ -66,4 +66,19 @@ final class TypesTest extends TestCase
         $this->assertFalse($checker->boolean('0'));
         $this->assertFalse($checker->boolean('1'));
     }
+
+    public function testBooleanStrict(): void
+    {
+        $checker = new TypeChecker();
+
+        $this->assertTrue($checker->boolean(true, true));
+        $this->assertTrue($checker->boolean(false, true));
+
+        $this->assertFalse($checker->boolean(1, true));
+        $this->assertFalse($checker->boolean(0, true));
+        $this->assertFalse($checker->boolean('true', true));
+        $this->assertFalse($checker->boolean('false', true));
+        $this->assertFalse($checker->boolean('0', true));
+        $this->assertFalse($checker->boolean('1', true));
+    }
 }


### PR DESCRIPTION
```php
$data = [
 'this_is_not_boolean' => 0,
 'this_is_boolean' => true,
];

// without strict
// validation will succeed
$validator->validate($data, [
  'this_is_not_boolean' => [
    ['type::boolean']
  ],
  'this_is_not_boolean' => [
    ['type::boolean']
  ]
]);


// with strict
// validation will fail because `this_is_not_boolean` is not boolean by type
$validator->validate($data, [
  'this_is_not_boolean' => [
    ['type::boolean', true]
  ],
  'this_is_not_boolean' => [
    ['type::boolean', true]
  ]
]);
```