### PR TITLE
[fix] DatetimeChecker::valid fix for brute values

### DIFF
--- a/src/Checker/DatetimeChecker.php
+++ b/src/Checker/DatetimeChecker.php
@@ -11,7 +11,7 @@ use Spiral\Validator\Checker\DatetimeChecker\ThresholdChecker;
 #[Singleton]
 final class DatetimeChecker extends AbstractChecker
 {
-    //COOKIE formal
+    //COOKIE format
     private const LONGEST_STR_FORMAT_LEN = 32;
     //PHP_MAX_INT 64 strlen
     private const LONGEST_INT_FORMAT_LEN = 19;

--- a/src/Checker/DatetimeChecker.php
+++ b/src/Checker/DatetimeChecker.php
@@ -129,7 +129,7 @@ final class DatetimeChecker extends AbstractChecker
                 $value = '0';
             }
 
-            return new \DateTimeImmutable(\is_numeric($value) ? \sprintf('@%d', $value) : \trim($value));
+            return new \DateTimeImmutable(\is_numeric($value) ? "@$value" : \trim($value));
         } catch (\Throwable) {
             //here's the fail;
         }

--- a/src/Checker/DatetimeChecker.php
+++ b/src/Checker/DatetimeChecker.php
@@ -11,6 +11,11 @@ use Spiral\Validator\Checker\DatetimeChecker\ThresholdChecker;
 #[Singleton]
 final class DatetimeChecker extends AbstractChecker
 {
+    //COOKIE formal
+    private const LONGEST_STR_FORMAT_LEN = 32;
+    //PHP_MAX_INT 64 strlen
+    private const LONGEST_INT_FORMAT_LEN = 19;
+
     public const MESSAGES = [
         'future'   => '[[Should be a date in the future.]]',
         'past'     => '[[Should be a date in the past.]]',
@@ -127,6 +132,17 @@ final class DatetimeChecker extends AbstractChecker
         try {
             if (!$value) {
                 $value = '0';
+            }
+
+            // in php below 8.2 a huge brute numeric values triggers exception
+            if (\is_string($value)) {
+                $maxLen = self::LONGEST_STR_FORMAT_LEN;
+                if (is_numeric($value)) {
+                    $maxLen =  self::LONGEST_INT_FORMAT_LEN;
+                }
+                if (\strlen($value) > $maxLen) {
+                    return null;
+                }
             }
 
             return new \DateTimeImmutable(\is_numeric($value) ? "@$value" : \trim($value));

--- a/tests/src/Unit/Checkers/DatetimeTest.php
+++ b/tests/src/Unit/Checkers/DatetimeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Validator\Tests\Unit\Checkers;
 
 use PHPUnit\Framework\TestCase;
+use Spiral\Validation\ValidatorInterface;
 use Spiral\Validator\Checker\DatetimeChecker;
 
 final class DatetimeTest extends TestCase
@@ -120,10 +121,10 @@ final class DatetimeTest extends TestCase
 
     /**
      * @dataProvider pastProvider
-     * @param bool  $expected
+     * @param bool $expected
      * @param mixed $value
-     * @param bool  $orNow
-     * @param bool  $useMicroseconds
+     * @param bool $orNow
+     * @param bool $useMicroseconds
      */
     public function testPast(bool $expected, $value, bool $orNow, bool $useMicroseconds): void
     {
@@ -170,8 +171,8 @@ final class DatetimeTest extends TestCase
 
     /**
      * @dataProvider formatProvider
-     * @param bool   $expected
-     * @param mixed  $value
+     * @param bool $expected
+     * @param mixed $value
      * @param string $format
      */
     public function testFormat(bool $expected, $value, string $format): void
@@ -207,7 +208,7 @@ final class DatetimeTest extends TestCase
 
     /**
      * @dataProvider validProvider
-     * @param bool  $expected
+     * @param bool $expected
      * @param mixed $value
      */
     public function testValid(bool $expected, mixed $value): void
@@ -281,11 +282,11 @@ final class DatetimeTest extends TestCase
 
     /**
      * @dataProvider beforeProvider
-     * @param bool  $expected
+     * @param bool $expected
      * @param mixed $value
      * @param mixed $threshold
-     * @param bool  $orEquals
-     * @param bool  $useMicroseconds
+     * @param bool $orEquals
+     * @param bool $useMicroseconds
      */
     public function testBefore(bool $expected, $value, $threshold, bool $orEquals, bool $useMicroseconds): void
     {
@@ -347,11 +348,11 @@ final class DatetimeTest extends TestCase
 
     /**
      * @dataProvider afterProvider
-     * @param bool  $expected
+     * @param bool $expected
      * @param mixed $value
      * @param mixed $threshold
-     * @param bool  $orEquals
-     * @param bool  $useMicroseconds
+     * @param bool $orEquals
+     * @param bool $useMicroseconds
      */
     public function testAfter(bool $expected, $value, $threshold, bool $orEquals, bool $useMicroseconds): void
     {

--- a/tests/src/Unit/Checkers/DatetimeTest.php
+++ b/tests/src/Unit/Checkers/DatetimeTest.php
@@ -6,7 +6,6 @@ namespace Spiral\Validator\Tests\Unit\Checkers;
 
 use PHPUnit\Framework\TestCase;
 use Spiral\Validator\Checker\DatetimeChecker;
-use Spiral\Validation\ValidatorInterface;
 
 final class DatetimeTest extends TestCase
 {
@@ -66,10 +65,10 @@ final class DatetimeTest extends TestCase
     /**
      * @dataProvider futureProvider
      *
-     * @param bool  $expected
+     * @param bool $expected
      * @param mixed $value
-     * @param bool  $orNow
-     * @param bool  $useMicroseconds
+     * @param bool $orNow
+     * @param bool $useMicroseconds
      */
     public function testFuture(bool $expected, $value, bool $orNow, bool $useMicroseconds): void
     {
@@ -211,7 +210,7 @@ final class DatetimeTest extends TestCase
      * @param bool  $expected
      * @param mixed $value
      */
-    public function testValid(bool $expected, $value): void
+    public function testValid(bool $expected, mixed $value): void
     {
         $checker = new DatetimeChecker();
 
@@ -221,27 +220,50 @@ final class DatetimeTest extends TestCase
     /**
      * @return array
      */
-    public function validProvider(): array
+    public function validProvider(): iterable
     {
-        return [
-            [true, time() - 1000,],
-            [true, time(),],
-            [true, date('u'),],
-            [true, time() + 1000,],
-            [true, '',],
-            [true, 'tomorrow +2hours',],
-            [true, 'yesterday -2hours',],
-            [true, 'now',],
-            [true, 'now + 1000 seconds',],
-            [true, 'now - 1000 seconds',],
-            [true, 0,],
-            [true, 1.1,],
-            [false, [],],
-            [false, false,],
-            [false, true,],
-            [false, null,],
-            [false, [],],
-            [false, new \stdClass(),],
+        yield [true, time() - 1000];
+        yield [true, time()];
+        yield [true, date('u')];
+        yield [true, time() + 1000];
+        yield [true, ''];
+        yield [true, 'tomorrow +2hours'];
+        yield [true, 'yesterday -2hours'];
+        yield [true, 'now'];
+        yield [true, 'now + 1000 seconds'];
+        yield [true, 'now - 1000 seconds'];
+        yield [true, 0];
+        yield [true, 1.1];
+        yield [false, []];
+        yield [false, false];
+        yield [false, true];
+        yield [false, null];
+        yield [false, []];
+        yield [false, new \stdClass()];
+
+        yield 'invalid datetime string' => [
+            false,
+            'you shall not pass',
+        ];
+
+        yield 'invalid numeric string' => [
+            false,
+            '2222222222222222222222222222222222222222222222222222222222222222',
+        ];
+
+        yield 'invalid integer' => [
+            false,
+            1111111111111111111111111111111111111111111111111111111111111111111111,
+        ];
+
+        yield 'scientific notation str' => [
+            false,
+            '1.23e-09',
+        ];
+
+        yield 'scientific notation num' => [
+            false,
+            1.23e-09,
         ];
     }
 
@@ -299,7 +321,7 @@ final class DatetimeTest extends TestCase
             [true, $this->inPast(1000), 'now', false, true],
             [true, $this->inPast(1000), 'now', true, true],
 
-            [true, 'yesterday -2hours', 'now', false, false],
+            [true, 'yesterday - 2hours', 'now', false, false],
             [true, 'now - 1000 seconds', 'now', false, false],
             [true, 'now + 1000 seconds', 'tomorrow', false, false],
 
@@ -364,7 +386,7 @@ final class DatetimeTest extends TestCase
             [true, $this->inFuture(1000), 'now', false, true],
             [true, $this->inFuture(1000), 'now', true, true],
 
-            [true, 'tomorrow +2hours', 'now', false, false],
+            [true, 'tomorrow + 2hours', 'now', false, false],
             [true, 'now + 1000 seconds', 'now', false, false],
             [true, 'now - 1000 seconds', 'yesterday', false, false],
 

--- a/tests/src/Unit/Checkers/DatetimeTest.php
+++ b/tests/src/Unit/Checkers/DatetimeTest.php
@@ -66,10 +66,10 @@ final class DatetimeTest extends TestCase
     /**
      * @dataProvider futureProvider
      *
-     * @param bool $expected
+     * @param bool  $expected
      * @param mixed $value
-     * @param bool $orNow
-     * @param bool $useMicroseconds
+     * @param bool  $orNow
+     * @param bool  $useMicroseconds
      */
     public function testFuture(bool $expected, $value, bool $orNow, bool $useMicroseconds): void
     {
@@ -121,10 +121,10 @@ final class DatetimeTest extends TestCase
 
     /**
      * @dataProvider pastProvider
-     * @param bool $expected
+     * @param bool  $expected
      * @param mixed $value
-     * @param bool $orNow
-     * @param bool $useMicroseconds
+     * @param bool  $orNow
+     * @param bool  $useMicroseconds
      */
     public function testPast(bool $expected, $value, bool $orNow, bool $useMicroseconds): void
     {
@@ -171,8 +171,8 @@ final class DatetimeTest extends TestCase
 
     /**
      * @dataProvider formatProvider
-     * @param bool $expected
-     * @param mixed $value
+     * @param bool   $expected
+     * @param mixed  $value
      * @param string $format
      */
     public function testFormat(bool $expected, $value, string $format): void
@@ -208,10 +208,10 @@ final class DatetimeTest extends TestCase
 
     /**
      * @dataProvider validProvider
-     * @param bool $expected
+     * @param bool  $expected
      * @param mixed $value
      */
-    public function testValid(bool $expected, mixed $value): void
+    public function testValid(bool $expected, $value): void
     {
         $checker = new DatetimeChecker();
 
@@ -333,11 +333,11 @@ final class DatetimeTest extends TestCase
 
     /**
      * @dataProvider beforeProvider
-     * @param bool $expected
+     * @param bool  $expected
      * @param mixed $value
      * @param mixed $threshold
-     * @param bool $orEquals
-     * @param bool $useMicroseconds
+     * @param bool  $orEquals
+     * @param bool  $useMicroseconds
      */
     public function testBefore(bool $expected, $value, $threshold, bool $orEquals, bool $useMicroseconds): void
     {
@@ -373,7 +373,7 @@ final class DatetimeTest extends TestCase
             [true, $this->inPast(1000), 'now', false, true],
             [true, $this->inPast(1000), 'now', true, true],
 
-            [true, 'yesterday - 2hours', 'now', false, false],
+            [true, 'yesterday -2hours', 'now', false, false],
             [true, 'now - 1000 seconds', 'now', false, false],
             [true, 'now + 1000 seconds', 'tomorrow', false, false],
 
@@ -399,11 +399,11 @@ final class DatetimeTest extends TestCase
 
     /**
      * @dataProvider afterProvider
-     * @param bool $expected
+     * @param bool  $expected
      * @param mixed $value
      * @param mixed $threshold
-     * @param bool $orEquals
-     * @param bool $useMicroseconds
+     * @param bool  $orEquals
+     * @param bool  $useMicroseconds
      */
     public function testAfter(bool $expected, $value, $threshold, bool $orEquals, bool $useMicroseconds): void
     {
@@ -438,7 +438,7 @@ final class DatetimeTest extends TestCase
             [true, $this->inFuture(1000), 'now', false, true],
             [true, $this->inFuture(1000), 'now', true, true],
 
-            [true, 'tomorrow + 2hours', 'now', false, false],
+            [true, 'tomorrow +2hours', 'now', false, false],
             [true, 'now + 1000 seconds', 'now', false, false],
             [true, 'now - 1000 seconds', 'yesterday', false, false],
 

--- a/tests/src/Unit/Checkers/DatetimeTest.php
+++ b/tests/src/Unit/Checkers/DatetimeTest.php
@@ -242,6 +242,57 @@ final class DatetimeTest extends TestCase
         yield [false, []];
         yield [false, new \stdClass()];
 
+        yield 'ATOM format' => [
+            true,
+            '2005-08-15T15:52:01+00:00',
+        ];
+        yield 'W3C format' => [
+            true,
+            '2005-08-15T15:52:01+00:00',
+        ];
+        yield 'COOKIE format' => [
+            true,
+            'Monday, 15-Aug-2005 15:52:01 UTC',
+        ];
+        yield 'RFC822 format' => [
+            true,
+            'Mon, 15 Aug 05 15:52:01 +0000',
+        ];
+        yield 'RFC1036 format' => [
+            true,
+            'Mon, 15 Aug 05 15:52:01 +0000',
+        ];
+        yield 'RFC850 format' => [
+            true,
+            'Monday, 15-Aug-05 15:52:01 UTC',
+        ];
+        yield 'RFC1123 format' => [
+            true,
+            'Mon, 15 Aug 2005 15:52:01 +0000',
+        ];
+        yield 'RFC7231 format' => [
+            true,
+            'Sat, 30 Apr 2016 17:52:13 GMT',
+        ];
+        yield 'RFC2822 format' => [
+            true,
+            'Mon, 15 Aug 2005 15:52:01 +0000',
+        ];
+        yield 'RFC3339_EXTENDED format' => [
+            true,
+            '2005-08-15T15:52:01.000+00:00',
+        ];
+        yield 'RSS format' => [
+            true,
+            'Mon, 15 Aug 2005 15:52:01 +0000',
+        ];
+        if (PHP_VERSION_ID >= 80200) {
+            yield 'ISO8601_EXPANDED format' => [
+                true,
+                '2005-08-15T15:52:01+0000',
+            ];
+        }
+
         yield 'invalid datetime string' => [
             false,
             'you shall not pass',


### PR DESCRIPTION
value `11111111111111111111111111111111111111111111111111111111111` not valid datetime string