### PR TITLE
Update CallableRule.php

### DIFF
--- a/src/CallableRule.php
+++ b/src/CallableRule.php
@@ -49,7 +49,7 @@ final class CallableRule extends AbstractRule
     public function getMessage(string $field, mixed $value): string
     {
         if (!empty($this->message)) {
-            return Translator::interpolate(
+            return $this->say(
                 $this->message,
                 \array_merge([$value, $field], $this->args),
             );


### PR DESCRIPTION
Fixed a bug where custom message translation was not performed

## What was changed

The interpolation method has been changed to call the translation method

## Why?

My filter looks like this
```php
class MyFilter extends Filter implements HasFilterDefinition
{
    #[Post]
    public string $name;
    
    public function filterDefinition(): FilterDefinitionInterface
    {
        return new FilterDefinition([
            'name' => [
                ['string', 'error' => '[[Must be a string]]']
            ]
        ]);
    }
}
```
and my translation file looks like this
```php
return [
    'Must be a string' => 'Поле должно быть строкой'
]
```

## Checklist

- Closes #
- Tested
    - [ ] Tested manually
    - [ ] Unit tests added
