### PR TITLE
String bytes

### DIFF
--- a/locale/ru/spiral-validator-checker-stringchecker.php
+++ b/locale/ru/spiral-validator-checker-stringchecker.php
@@ -10,4 +10,9 @@ return [
     'Text length should be in range of {1}-{2}.' => 'Длина текста должна быть от {1} до {2}.',
     'String value should be empty.' => 'Строка должна быть пустой.',
     'String value should not be empty.' => 'Строка не должна быть пустой.',
+    // bytes
+    'Enter text in bytes shorter or equal to {1}.' => 'Длина текста в байтах должна быть меньше или равна {1}.',
+    'Text in bytes must be longer or equal to {1}.' => 'Длина текста в байтах должна быть больше или равна {1}.',
+    'Text in bytes length must be exactly equal to {1}.' => 'Длина текста в байтах должна быть равна {1}.',
+    'Text in bytes length should be in range of {1}-{2}.' => 'Длина текста в байтах должна быть от {1} до {2}.',
 ];

--- a/src/Checker/FileChecker.php
+++ b/src/Checker/FileChecker.php
@@ -47,7 +47,7 @@ final class FileChecker extends AbstractChecker
     }
 
     /**
-     * Check if file size less that specified value in KB.
+     * Check if file size less that specified value in KiB.
      *
      * @param mixed $file Local file or uploaded file array.
      * @param int   $size Size in KBytes.

--- a/src/Checker/StringChecker.php
+++ b/src/Checker/StringChecker.php
@@ -18,6 +18,11 @@ final class StringChecker extends AbstractChecker
         'range'    => '[[Text length should be in range of {1}-{2}.]]',
         'empty'    => '[[String value should be empty.]]',
         'notEmpty' => '[[String value should not be empty.]]',
+        // bytes
+        'shorterBytes' => '[[Enter text in bytes shorter or equal to {1}.]]',
+        'longerBytes' => '[[Text in bytes must be longer or equal to {1}.]]',
+        'lengthBytes' => '[[Text in bytes length must be exactly equal to {1}.]]',
+        'rangeBytes' => '[[Text length should be in range of {1}-{2}.]]',
     ];
 
     /**
@@ -81,5 +86,32 @@ final class StringChecker extends AbstractChecker
     public function notEmpty(mixed $value): bool
     {
         return \is_string($value) && \trim($value) !== '';
+    }
+
+    public function shorterBytes(mixed $value, int $length): bool
+    {
+        return \is_string($value) && \strlen(\trim($value)) <= $length;
+    }
+
+    public function longerBytes(mixed $value, int $length): bool
+    {
+        return \is_string($value) && \strlen(\trim($value)) >= $length;
+    }
+
+    public function lengthBytes(mixed $value, int $length): bool
+    {
+        return \is_string($value) && \strlen(\trim($value)) === $length;
+    }
+
+    public function rangeBytes(mixed $value, int $min, int $max): bool
+    {
+        if (!\is_string($value)) {
+            return false;
+        }
+
+        $trimmed = \trim($value);
+
+        return (\strlen($trimmed) >= $min)
+            && (\strlen($trimmed) <= $max);
     }
 }

--- a/tests/src/Unit/Checkers/StringsTest.php
+++ b/tests/src/Unit/Checkers/StringsTest.php
@@ -117,6 +117,126 @@ final class StringsTest extends TestCase
         $this->assertFalse($checker->regexp([], '/^ab[dEC]{3}/i'));
     }
 
+    /**
+     * @dataProvider dpShorterBytes
+     */
+    public function testShorterBytes(mixed $text, int $val, bool $expected = true): void
+    {
+        $this->assertEquals(
+            $expected,
+            (new StringChecker())->shorterBytes($text, $val),
+        );
+    }
+
+    public function dpShorterBytes(): iterable
+    {
+        yield ['abc', 2, false];
+        yield ['abc', 3, true];
+
+        yield ['абв', 2, false];
+        yield ['абв', 3, false];
+        yield ['абв', 4, false];
+        yield ['абв', 6, true];
+
+        yield ['😀', 2, false];
+        yield ['😀', 3, false];
+        yield ['😀', 4, true];
+
+        yield [null, 0, false];
+        yield [[], 0, false];
+    }
+
+    /**
+     * @dataProvider dpLongerBytes
+     */
+    public function testLongerBytes(mixed $text, int $val, bool $expected = true): void
+    {
+        $this->assertEquals(
+            $expected,
+            (new StringChecker())->longerBytes($text, $val),
+        );
+    }
+
+    public function dpLongerBytes(): iterable
+    {
+        yield ['a', 2, false];
+        yield ['ab', 2, true];
+
+        yield ['а', 1, true];
+        yield ['а', 2, true];
+        yield ['аб', 3, true];
+        yield ['аб', 4, true];
+        yield ['аб', 5, false];
+
+        yield ['😀', 1, true];
+        yield ['😀', 2, true];
+        yield ['😀', 3, true];
+        yield ['😀', 4, true];
+        yield ['😀', 5, false];
+
+        yield [null, 0, false];
+        yield [[], 0, false];
+    }
+
+    /**
+     * @dataProvider dpLengthBytes
+     */
+    public function testLengthBytes(mixed $text, int $val, bool $expected = true): void
+    {
+        $this->assertEquals(
+            $expected,
+            (new StringChecker())->lengthBytes($text, $val),
+        );
+    }
+
+    public function dpLengthBytes(): iterable
+    {
+        yield ['a', 1, true];
+        yield ['ab', 2, true];
+        yield ['ab', 1, false];
+
+        yield ['а', 1, false];
+        yield ['а', 2, true];
+        yield ['аб', 4, true];
+        yield ['абв', 6, true];
+        yield ['абв', 5, false];
+
+        yield ['😀', 1, false];
+        yield ['😀', 4, true];
+
+        yield [null, 0, false];
+        yield [[], 0, false];
+    }
+
+    /**
+     * @dataProvider dbRangeBytes
+     */
+    public function testRangeBytes(mixed $text, int $v1, int $v2, bool $expected = true): void
+    {
+        $this->assertEquals(
+            $expected,
+            (new StringChecker())->rangeBytes($text, $v1, $v2),
+        );
+    }
+
+    public function dbRangeBytes(): iterable
+    {
+        yield ['abc', 2, 6, true];
+        yield ['abc', 0, 3, true];
+        yield ['abc', 5, 10, false];
+
+        yield ['абв', 1, 100, true];
+        yield ['абв', 3, 20, true];
+        yield ['абв', 0, 6, true];
+
+        yield ['😀', 0, 2, false];
+        yield ['😀', 0, 4, true];
+        yield ['😀', 4, 4, true];
+
+        yield [null, 0, 2, false];
+        yield [[], 0, 2, false];
+    }
+
     #[DataProvider('dataEmpty')]
     public function testEmpty(mixed $value, bool $expectedResult): void
     {


### PR DESCRIPTION
## What was changed

When user send message to our glorious backend, I want to insert it to our brand new table with TEXT column.
But text length in bytes differ for `A`, `Я` and 😀.

## Why?

exception 500 is not an option

## Checklist

- Closes #
- Tested
    - [x] Tested manually
    - [x] Unit tests added

## Documentation <!--- Remove if not needed -->
