### PR TITLE
Add uppercase and lowercase string checks

### DIFF
--- a/locale/ru/spiral-validator-checker-stringchecker.php
+++ b/locale/ru/spiral-validator-checker-stringchecker.php
@@ -10,6 +10,8 @@ return [
     'Text length should be in range of {1}-{2}.' => 'Длина текста должна быть от {1} до {2}.',
     'String value should be empty.' => 'Строка должна быть пустой.',
     'String value should not be empty.' => 'Строка не должна быть пустой.',
+    'String value should be in upper case.' => 'Строка должна быть в верхнем регистре.',
+    'String value should be in lower case.' => 'Строка должна быть в нижнем регистре.',
     // bytes
     'Enter text in bytes shorter or equal to {1}.' => 'Длина текста в байтах должна быть меньше или равна {1}.',
     'Text in bytes must be longer or equal to {1}.' => 'Длина текста в байтах должна быть больше или равна {1}.',

--- a/src/Checker/StringChecker.php
+++ b/src/Checker/StringChecker.php
@@ -91,7 +91,7 @@ final class StringChecker extends AbstractChecker
     }
 
     /**
-     * Check that string contains no lower case characters, e.g. country or currency codes.
+     * Check that string contains no lower case characters.
      * Characters without case (digits, punctuation) are ignored.
      */
     public function uppercase(mixed $value): bool
@@ -100,7 +100,7 @@ final class StringChecker extends AbstractChecker
     }
 
     /**
-     * Check that string contains no upper case characters, e.g. slugs, html pages, agent names.
+     * Check that string contains no upper case characters.
      * Characters without case (digits, punctuation) are ignored.
      */
     public function lowercase(mixed $value): bool

--- a/src/Checker/StringChecker.php
+++ b/src/Checker/StringChecker.php
@@ -18,6 +18,8 @@ final class StringChecker extends AbstractChecker
         'range'    => '[[Text length should be in range of {1}-{2}.]]',
         'empty'    => '[[String value should be empty.]]',
         'notEmpty' => '[[String value should not be empty.]]',
+        'uppercase' => '[[String value should be in upper case.]]',
+        'lowercase' => '[[String value should be in lower case.]]',
         // bytes
         'shorterBytes' => '[[Enter text in bytes shorter or equal to {1}.]]',
         'longerBytes' => '[[Text in bytes must be longer or equal to {1}.]]',
@@ -86,6 +88,24 @@ final class StringChecker extends AbstractChecker
     public function notEmpty(mixed $value): bool
     {
         return \is_string($value) && \trim($value) !== '';
+    }
+
+    /**
+     * Check that string contains no lower case characters, e.g. country or currency codes.
+     * Characters without case (digits, punctuation) are ignored.
+     */
+    public function uppercase(mixed $value): bool
+    {
+        return \is_string($value) && \mb_strtoupper($value) === $value;
+    }
+
+    /**
+     * Check that string contains no upper case characters, e.g. slugs, html pages, agent names.
+     * Characters without case (digits, punctuation) are ignored.
+     */
+    public function lowercase(mixed $value): bool
+    {
+        return \is_string($value) && \mb_strtolower($value) === $value;
     }
 
     public function shorterBytes(mixed $value, int $length): bool

--- a/tests/src/Unit/Checkers/StringsTest.php
+++ b/tests/src/Unit/Checkers/StringsTest.php
@@ -237,6 +237,64 @@ final class StringsTest extends TestCase
         yield [[], 0, 2, false];
     }
 
+    public static function dataUppercase(): iterable
+    {
+        yield ['USD', true];
+        yield ['RU', true];
+        yield ['ISO-4217', true];
+        yield ['ПРИВЕТ', true];
+        // no cased characters at all
+        yield ['', true];
+        yield ['123', true];
+        yield ['😀', true];
+
+        yield ['usd', false];
+        yield ['Usd', false];
+        yield ['USd', false];
+        yield ['Привет', false];
+        //not string
+        yield [null, false];
+        yield [1, false];
+        yield [1.0, false];
+        yield [[], false];
+        yield [new \stdClass(), false];
+    }
+
+    public static function dataLowercase(): iterable
+    {
+        yield ['my-slug', true];
+        yield ['index.html', true];
+        yield ['code-reviewer', true];
+        yield ['привет', true];
+        // no cased characters at all
+        yield ['', true];
+        yield ['123', true];
+        yield ['😀', true];
+
+        yield ['My-Slug', false];
+        yield ['SLUG', false];
+        yield ['slUg', false];
+        yield ['Привет', false];
+        //not string
+        yield [null, false];
+        yield [1, false];
+        yield [1.0, false];
+        yield [[], false];
+        yield [new \stdClass(), false];
+    }
+
+    #[DataProvider('dataUppercase')]
+    public function testUppercase(mixed $value, bool $expectedResult): void
+    {
+        self::assertSame($expectedResult, (new StringChecker())->uppercase($value));
+    }
+
+    #[DataProvider('dataLowercase')]
+    public function testLowercase(mixed $value, bool $expectedResult): void
+    {
+        self::assertSame($expectedResult, (new StringChecker())->lowercase($value));
+    }
+
     #[DataProvider('dataEmpty')]
     public function testEmpty(mixed $value, bool $expectedResult): void
     {


### PR DESCRIPTION
## What

Two new checks in `StringChecker`:

- `string::uppercase` — value must contain no lower case characters (country/currency codes, e.g. `USD`, `RU`)
- `string::lowercase` — value must contain no upper case characters (slugs, html page names, e.g. `my-slug`, `index.html`)

```php
public function uppercase(mixed $value): bool
{
    return \is_string($value) && \mb_strtoupper($value) === $value;
}
```

## Notes

- `mb_*` comparison, so unicode works (`ПРИВЕТ` / `привет`) and caseless characters are ignored — `ISO-4217`, `index.html`, `123`, `😀` pass both checks.
- Empty string passes both, consistent with the other length-based checks in this checker; combine with `string::notEmpty` when needed.
- Method names match the existing `PasswordChecker::uppercase()` / `lowercase()` convention (semantics differ there: "at least N characters of that case").
- Messages added to `MESSAGES` plus `ru` translations.
- Unit tests added to `StringsTest` (32 data cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)